### PR TITLE
Try to fix Appveyor on Windows Visual Studio 2019 / macOS clang / Ubu…

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,11 +1,11 @@
-version: 1.0.{build}
+version: 24.07.{build}
 
 image:
+  - Visual Studio 2019
   - macOS
   - Ubuntu1804
-  - Visual Studio 2019
 
-stack: python 3.7
+stack: python 3.9
 
 for:
   # macOS 
@@ -18,14 +18,15 @@ for:
 
     init:
        - export PATH="$HOME/Qt/5.15.2/clang_64/bin:$HOME/venv3.9/bin:$PATH"
-       - python -m pip install --upgrade pip
-       - pip install conan
+       - python3 -m pip install --upgrade pip
+       - pip install conan==1.60.1
        - conan user
        - conan remote add simcenter https://nherisimcenter.jfrog.io/artifactory/api/conan/simcenter
 
     install:
        - uname
-       - git clone https://github.com/NHERI-SimCenter/SimCenterBackendApplications.git       
+       - rm -rf SimCenterBackendApplications
+       - git clone https://github.com/JustinBonus/SimCenterBackendApplications.git       
 
     build_script:
 
@@ -39,6 +40,7 @@ for:
        - qmake --version
        - gcc --version
        - python --version
+       - python3 --version
 
   # Ubuntu1804 
   -
@@ -49,18 +51,19 @@ for:
     clone_folder: ~/SimCenter
 
     init:
-       - export PATH="$HOME/Qt/5.15.2/gcc_64/bin:$HOME/venv3.8.6/bin:$PATH"
+       - export PATH="$HOME/Qt/5.15.2/gcc_64/bin:$HOME/venv3.9/bin:$PATH"
        - export PATH="/home/appveyor/.local/bin:$PATH"
        
     install:
        - uname
        - sudo update-alternatives --set gcc /usr/bin/gcc-9
        - sudo apt-get -y install libglu1-mesa-dev freeglut3-dev mesa-common-dev libblas-dev liblapack-dev
-       - python -m pip install --upgrade pip
-       - pip install conan
+       - python3 -m pip install --upgrade pip
+       - pip install conan==1.60.1
        - conan user
        - conan remote add simcenter https://nherisimcenter.jfrog.io/artifactory/api/conan/simcenter
-       - git clone https://github.com/NHERI-SimCenter/SimCenterBackendApplications.git
+       - rm -rf SimCenterBackendApplications
+       - git clone https://github.com/JustinBonus/SimCenterBackendApplications.git
        
     build_script:
        # build SimCenterBackendApplications
@@ -73,6 +76,7 @@ for:
        - qmake --version
        - gcc --version
        - python --version
+       - python3 --version
 
   # Visual Studio 2019
   -
@@ -85,11 +89,11 @@ for:
 
     init:
        - cmd: set PYTHON=C:\PYTHON38-x64
-       - cmd: set PYTHONNET_PYDLL=%PYTHON%\python3.8.dll
+       - cmd: set PYTHONNET_PYDLL=%PYTHON%\python3.9.dll
        - cmd: set QT=C:\Qt\5.15.2\msvc2019_64\bin
        - cmd: set PATH=%PYTHON%;%PYTHON%\Scripts;%QT%;%PATH%
        - cmd: call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars64.bat"
-       - cmd: pip.exe install conan
+       - cmd: pip.exe install conan==1.60.1
        - cmd: conan user
        - cmd: conan profile new default --detect
        - cmd: conan profile show default
@@ -99,7 +103,8 @@ for:
        - cmd: echo %PATH%
 
     install:
-       - cmd: git clone https://github.com/NHERI-SimCenter/SimCenterBackendApplications.git
+       - cmd: rm -rf SimCenterBackendApplications
+       - cmd: git clone https://github.com/JustinBonus/SimCenterBackendApplications.git
        - cmd: dir
 
     build_script:


### PR DESCRIPTION
…ntu18.04 gcc-9

Trying to update the appveyor to use appropriate Conan version, properly specify Python 3.9, set a version matching the {last 2 digits of year}:{month}:{build} format, etc

For now it is set to clone my personal SimCenterBackendApplications repo, so that I can trigger an appveyor build with my commits there, but this should be reverted for the main NHERI-SimCenter repo